### PR TITLE
Split rogue if statement into two.

### DIFF
--- a/src/io/github/dead_i/bungeerelay/IRC.java
+++ b/src/io/github/dead_i/bungeerelay/IRC.java
@@ -227,9 +227,11 @@ public class IRC {
                 }else if (cm[0].contains(m) || cm[1].contains(m) || (cm[2].contains(m) && d.equals("+"))) {
                     s = s + ex[v] + " ";
                     v++;
-                }else if (ex.length >= v && users.containsKey(ex[v])) {
-                    s = s + users.get(ex[v]) + " ";
-                    v++;
+                }else if (ex.length >= v) {
+                    if (users.containsKey(ex[v])) {
+                        s = s + users.get(ex[v]) + " ";
+                        v++;
+                    }
                 }
             }
             for (ProxiedPlayer p : Util.getPlayersByChannel(ex[2])) {


### PR DESCRIPTION
It was testing whether the value was in bounds, but it was still trying to access the data for the rest of the if statement. This wouldn't happen in C.
